### PR TITLE
Quotes around the variable identifiers {{ and }}

### DIFF
--- a/doc/lab-005.md
+++ b/doc/lab-005.md
@@ -20,8 +20,8 @@ Add these variables to our exsisting mysqldb plays.
 ```yml
 - name: create demo user
   mysql_user:
-    name: {{ mysqluser }}
-    password: {{ mysqlpass }}
+    name: "{{ mysqluser }}"
+    password: "{{ mysqlpass }}"
     priv: demo.*:ALL
     host: '%'
     state: present


### PR DESCRIPTION
Ansible complains if quotes are missing, playbook execution fails - fixed once quotes in place